### PR TITLE
Check for published status on save.

### DIFF
--- a/app/domain/Lio/Articles/Article.php
+++ b/app/domain/Lio/Articles/Article.php
@@ -90,9 +90,6 @@ class Article extends EloquentBaseModel implements SlugInterface
         if($this->status == static::STATUS_PUBLISHED && empty($this->published_at)) {
             $this->published_at = $this->freshTimestamp();
         }
-        else if($this->status == static::STATUS_DRAFT && $this->published_at) {
-            $this->published_at = null;
-        }
 
         return parent::save($options);
     }


### PR DESCRIPTION
If the article is published but no published_at date exists, set it
before saving the model.

If the article is set to draft but has a published_at date, set the
published_at date to null.

Signed-off-by: Spencer Deinum spencerdeinum@gmail.com
