### PR TITLE
Remove URL from Gist embeds

### DIFF
--- a/app/Lio/Github/GistEmbedFormatter.php
+++ b/app/Lio/Github/GistEmbedFormatter.php
@@ -6,6 +6,6 @@ class GistEmbedFormatter
 
     public function format($html)
     {
-        return preg_replace($this->pattern, '<a href="$0">$0</a><script src="$0.js"></script>', $html);
+        return preg_replace($this->pattern, '<script src="$0.js"></script>', $html);
     }
 }


### PR DESCRIPTION
Reverts the commit from 30f1aa3 and removes the Github Gist URL from appearing above the embedded gist.

The URLs are redundant as one could click the filename in the gist and be taken to its page if they want.
