### PR TITLE
Add beginning stages for API endpoints

### DIFF
--- a/app/controllers/Api/Forum/ForumThreadsController.php
+++ b/app/controllers/Api/Forum/ForumThreadsController.php
@@ -1,0 +1,36 @@
+<?php namespace Api;
+
+use Lio\Forum\Threads\ThreadRepository;
+use Lio\Tags\TagRepository;
+use BaseController;
+use Input;
+use URL;
+
+class ForumThreadsController extends BaseController
+{
+    protected $threadsPerPage = 50;
+    protected $threads;
+    protected $tags;
+
+    public function __construct(ThreadRepository $threads, TagRepository $tags)
+    {
+        $this->threads = $threads;
+        $this->tags    = $tags;
+    }
+
+    public function getIndex($status = '')
+    {
+        $threadCount = Input::get('take', $this->threadsPerPage);
+        $tags        = $this->tags->getAllTagsBySlug(Input::get('tags'));
+        $threads     = $this->threads->getByTagsAndStatusPaginated($tags, $status, $threadCount);
+
+        $collection = $threads->getCollection();
+
+        $collection->each(function($thread) {
+            $thread->url = URL::action('ForumThreadsController@getShowThread', ['slug' => $thread->slug]);
+        });
+
+        // We want the newest threads to come out in chronological order
+        return $collection->reverse();
+    }
+}

--- a/app/routes.php
+++ b/app/routes.php
@@ -88,6 +88,8 @@ Route::get('forum/search', 'ForumThreadsController@getSearch');
 Route::get('forum/{slug}/reply/{commentId}', 'ForumRepliesController@getReplyRedirect');
 Route::get('forum/{slug}', ['before' => '', 'uses' => 'ForumThreadsController@getShowThread']);
 
+Route::get('api/forum', 'Api\ForumThreadsController@getIndex');
+
 // admin
 Route::group(['before' => 'auth', 'prefix' => 'admin'], function() {
 


### PR DESCRIPTION
Naive first step toward having an API for Lio.  It's goal is to allow for easy content delivery, discovery, aggregation, and integration with internal and external services.

At the moment it's a typical RESTful response where it returns an array of objects from the appropriate collection, but I'd like to move this towards HATEOAS/HAL soon if we think that'll help benefit us.

Additionally, this code could be abstracted and cleaned up but this is just a quick fix to get Liona's features back up to where Rommie was.
