### PR TITLE
Made bin view horizontally scrollable

### DIFF
--- a/public/scss/modules/_bin.scss
+++ b/public/scss/modules/_bin.scss
@@ -11,7 +11,12 @@ body.bin {
         position: absolute;
         right: -100%;
     }
-
+    
+    .show-container {
+        width: 200%;
+        overflow-x: scroll;
+    }
+    
     .prettyprint {
         border: 0;
         margin-bottom: 0;


### PR DESCRIPTION
Fixes this http://d.pr/i/IfSI

Fixes the fact that you have a 30% (sometimes 250px) sidebar overlapping the code. It also fixes insane line wrapping.

One could argue that you should instead make your sidebar position: absolute; so it isn't overlapping, but that wouldn't fix the line wrapping and would take more rewriting.
