### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ composer-download:
 # Perform a composer install
 # Use: make composer-install
 composer-install:
-	@$(VAGRANTSSH) "cd /vagrant && php composer.phar install"
+	@$(VAGRANTSSH) "cd /vagrant && php composer.phar install --no-dev"
 
 # Perform a composer install with --dev
 # Use: make composer-install-dev


### PR DESCRIPTION
Composer now requires --no-dev for the development dependencies not to be installed.
