### PR TITLE
Navigate to replay after updating it

### DIFF
--- a/app/controllers/Forum/ForumRepliesController.php
+++ b/app/controllers/Forum/ForumRepliesController.php
@@ -95,7 +95,8 @@ class ForumRepliesController extends BaseController implements
 
     public function replyUpdated($reply)
     {
-        return $this->redirectAction('ForumThreadsController@getShowThread', [$reply->thread->slug]);
+        $replyPresenter = new ReplyPresenter($reply);
+        return $this->redirectTo($replyPresenter->url);
     }
 
     // reply deletion


### PR DESCRIPTION
It would be good UX to show the reply after editing it rather than the thread's first page.
