### PR TITLE
Update modules/_bin.scss, scrollbar over sidebar

### DIFF
--- a/public/scss/modules/_bin.scss
+++ b/public/scss/modules/_bin.scss
@@ -49,6 +49,7 @@ body.bin {
         outline: none;
         font-size: 12px;
         -webkit-font-smoothing: antialiased;
+        z-index: 1;
     }
 
     .sidebar {


### PR DESCRIPTION
Add a z-index to the editor so that the scrollbar is placed over the sidebar.
To reproduce "bug": write multiple lines, scroll.

Thanks in advance :)
— PunKeel

PS: I have reviewed guidelines for contributing ... but it's empty :(
