### PR TITLE
Fix Pastebin vendor prefix issue on iOS

### DIFF
--- a/public/scss/modules/_bin.scss
+++ b/public/scss/modules/_bin.scss
@@ -98,6 +98,7 @@ body.bin {
         padding: 15px;
         position: fixed;
         right: 0;
+        -webkit-transition: -webkit-transform $sidebar_transition;
         transition: transform $sidebar_transition;
         top: 0;
         width: 50%;
@@ -137,6 +138,7 @@ body.bin {
         }
 
         &.hide {
+            -webkit-transform: translateX(100%);
             transform: translateX(100%);
         }
     }


### PR DESCRIPTION
My original responsive commit was missing the webkit vendor prefix, so parts of the pastebin didn't work correctly on iOS.
