### PR TITLE
If applied this commit adds the option to allow the users to sign in from a thread's page.

### DIFF
--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -110,7 +110,14 @@
                     {!! Form::hidden('replyable_type', 'threads') !!}
                     {!! Form::submit('Reply', ['class' => 'btn btn-primary btn-block']) !!}
                 {!! Form::close() !!}
+            @endcan
+
+            <hr>
+            
+            @if(!Auth::check())
+                <p class="text-center"><a href="{{ route('login') }}">Sign in</a> to participate in this thread!</p>
             @endif
+
         </div>
     </div>
 @endsection

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -114,10 +114,11 @@
 
             <hr>
             
-            @if(Auth::guest())
-                <p class="text-center"><a href="{{ route('login') }}">Sign in</a> to participate in this thread!</p>
+            @if (Auth::guest())
+                <p class="text-center">
+                    <a href="{{ route('login') }}">Sign in</a> to participate in this thread!
+                </p>
             @endif
-
         </div>
     </div>
 @endsection

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -114,7 +114,7 @@
 
             <hr>
             
-            @if(!Auth::check())
+            @if(Auth::guest())
                 <p class="text-center"><a href="{{ route('login') }}">Sign in</a> to participate in this thread!</p>
             @endif
 


### PR DESCRIPTION
- This PR adds the option to sign in at the thread's bottom if the user is logged out. It looks as follows

![pr1-lio](https://user-images.githubusercontent.com/11228182/27302525-0116bf4a-5555-11e7-92d5-0ebcedfe4f70.png)

- While reading a thread if the reader/user wants to contribute, the immediate instinct is to sign in the fastest way possible and help a co-dev out. 

- It also fixes a small typo: `endif` to `endcan`

Open for improvements if needed :)
