### PR TITLE
If applied this commit re-orders the tags part to below the threads list on sm and xs devices

### DIFF
--- a/resources/assets/sass/_forum.scss
+++ b/resources/assets/sass/_forum.scss
@@ -3,3 +3,9 @@
         max-width: 100%;
     }
 }
+
+@media (max-width: 991px) {
+  .threads-column {
+    margin-top: 10px;
+  }
+}

--- a/resources/views/forum/_tags.blade.php
+++ b/resources/views/forum/_tags.blade.php
@@ -1,0 +1,11 @@
+<h3>Tags</h3>
+<div class="list-group">
+    <a href="{{ route('forum') }}" class="list-group-item {{ active('forum*', ! isset($activeTag) || $activeTag === null) }}">All</a>
+
+    @foreach (App\Models\Tag::orderBy('name')->get() as $tag)
+        <a href="{{ route('forum.tag', $tag->slug()) }}"
+           class="list-group-item{{ isset($activeTag) && $tag->matches($activeTag) ? ' active' : '' }}">
+            {{ $tag->name() }}
+        </a>
+    @endforeach
+</div>

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -21,7 +21,7 @@
                 @include('forum._tags')
             </div>
         </div>
-        <div class="col-md-9">
+        <div class="col-md-9 threads-column">
             @if (count($threads))
                 @foreach ($threads as $thread)
                     <div class="panel panel-default">

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -17,16 +17,8 @@
 
             <a class="btn btn-success btn-block" href="{{ route('threads.create') }}">Create Thread</a>
 
-            <h3>Tags</h3>
-            <div class="list-group">
-                <a href="{{ route('forum') }}" class="list-group-item {{ active('forum*', ! isset($activeTag) || $activeTag === null) }}">All</a>
-
-                @foreach (App\Models\Tag::orderBy('name')->get() as $tag)
-                    <a href="{{ route('forum.tag', $tag->slug()) }}"
-                       class="list-group-item{{ isset($activeTag) && $tag->matches($activeTag) ? ' active' : '' }}">
-                        {{ $tag->name() }}
-                    </a>
-                @endforeach
+            <div class="hidden-xs hidden-sm">
+                @include('forum._tags')
             </div>
         </div>
         <div class="col-md-9">
@@ -63,6 +55,9 @@
                     <a href="{{ route('threads.create') }}" class="alert-link">Create a new one.</a>
                 </div>
             @endif
+        </div>
+        <div class="visible-xs visible-sm">
+            @include('forum._tags')
         </div>
     </div>
 @endsection

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -56,7 +56,7 @@
                 </div>
             @endif
         </div>
-        <div class="visible-xs visible-sm">
+        <div class="col-xs-12 visible-xs visible-sm">
             @include('forum._tags')
         </div>
     </div>


### PR DESCRIPTION
- Right now on the small and extra-small screens, the `tags` section is shown on top of the threads list that makes the user scroll down a lot to reach the threads list. 
- A lot of people (including me :stuck_out_tongue_winking_eye:) browse the forum via our mobile phones as well so it's a sort of unnecessary repeated task right now.
- The proposed solution/hack might not be the most efficient way to achieve the said, so a PHP dev is open to learning some front end fundamentals from you guys :)
- The PR results in re-ordering the tags below the threads list as follows:

![pr2-lio](https://user-images.githubusercontent.com/11228182/27342914-199a629c-55ff-11e7-9fd7-f112e96304aa.png)
