### PR TITLE
Vagrant Path (Readme file) and .vagrant path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 .env
 /aliases
 /after.sh
+.vagrant

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ The following tools are required in order to start the installation.
 1. Clone this repository: `git clone git@github.com:laravelio/laravel-io.git ~/Sites/laravelio`
 2. Run `composer start`
 4. Run `vagrant up`
-5. SSH into your Vagrant box, go to `/home/vagrant/Code/laravelio` and run `composer setup`
+5. SSH into your Vagrant box, go to `/home/vagrant/Code/portal` and run `composer setup`
 6. Add `192.168.10.10 laravelio.app` to your computer's `/etc/hosts` file
 7. Setup a working e-mail driver like [Mailtrap](https://mailtrap.io/)
 8. (optional) Set up Github authentication (see below)


### PR DESCRIPTION
I just followed the readme file instructions and the only thing wrong was this path.

This PR include:

1. Small fix in README file - wrong vagrant path
1. `.vagrant` path into .gitignore file.