### PR TITLE
Allow multiple spaces between words in subject

### DIFF
--- a/app/Validation/DoesNotContainUrlRule.php
+++ b/app/Validation/DoesNotContainUrlRule.php
@@ -22,7 +22,7 @@ class DoesNotContainUrlRule
     {
         return ! collect(explode(' ', $value))->contains(function ($word) {
             return $this->validator
-                ->make(compact('word'), ['word' => 'url'])
+                ->make(compact('word'), ['word' => 'url|required'])
                 ->passes();
         });
     }

--- a/tests/Components/Validation/DoesNotContainUrlRuleTest.php
+++ b/tests/Components/Validation/DoesNotContainUrlRuleTest.php
@@ -10,6 +10,7 @@ class DoesNotContainUrlRuleTest extends TestCase
     const STRING_WITH_URL = 'This is a string http://example.com with an url in it.';
     const STRING_WITHOUT_URL = 'This is a string without an url in it.';
     const STRING_WITH_A_REGRESSION = 'JSON not possible with MSSQL running on Windows platform?';
+    const STRING_WITH_EXTRA_SPACES = 'This  is a  string with extra spaces.';
 
     /** @test */
     public function it_detects_a_url_in_a_string()
@@ -21,6 +22,12 @@ class DoesNotContainUrlRuleTest extends TestCase
     public function it_passes_when_no_url_is_present()
     {
         $this->assertTrue($this->runRule(self::STRING_WITHOUT_URL));
+    }
+
+    /** @test */
+    public function it_passes_when_extra_spaces_are_present()
+    {
+        $this->assertTrue($this->runRule(self::STRING_WITH_EXTRA_SPACES));
     }
 
     private function runRule(string $value): bool

--- a/tests/Components/Validation/DoesNotContainUrlRuleTest.php
+++ b/tests/Components/Validation/DoesNotContainUrlRuleTest.php
@@ -9,7 +9,6 @@ class DoesNotContainUrlRuleTest extends TestCase
 {
     const STRING_WITH_URL = 'This is a string http://example.com with an url in it.';
     const STRING_WITHOUT_URL = 'This is a string without an url in it.';
-    const STRING_WITH_A_REGRESSION = 'JSON not possible with MSSQL running on Windows platform?';
     const STRING_WITH_EXTRA_SPACES = 'This  is a  string with extra spaces.';
 
     /** @test */

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -59,6 +59,25 @@ class ForumTest extends BrowserKitTestCase
     }
 
     /** @test */
+    public function the_thread_subject_may_contain_multiple_spaces_between_words()
+    {
+        $tag = factory(Tag::class)->create(['name' => 'Foo Tag']);
+
+        $this->login();
+
+        $this->visit('/forum/create-thread')
+            ->submitForm('Create Thread', [
+                'subject' => 'This  is a Foo title',
+                'body' => 'This text explains how queues work in Laravel.',
+                'tags' => [$tag->id()],
+            ])
+            ->seePageIs('/forum/this-is-a-foo-title')
+            ->see('how queues work in Laravel.')
+            ->see('Foo Tag')
+            ->see('Thread successfully created!');
+    }
+
+    /** @test */
     public function users_can_create_a_thread()
     {
         $tag = factory(Tag::class)->create(['name' => 'Test Tag']);

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -59,25 +59,6 @@ class ForumTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function the_thread_subject_may_contain_multiple_spaces_between_words()
-    {
-        $tag = factory(Tag::class)->create(['name' => 'Foo Tag']);
-
-        $this->login();
-
-        $this->visit('/forum/create-thread')
-            ->submitForm('Create Thread', [
-                'subject' => 'This  is a Foo title',
-                'body' => 'This text explains how queues work in Laravel.',
-                'tags' => [$tag->id()],
-            ])
-            ->seePageIs('/forum/this-is-a-foo-title')
-            ->see('how queues work in Laravel.')
-            ->see('Foo Tag')
-            ->see('Thread successfully created!');
-    }
-
-    /** @test */
     public function users_can_create_a_thread()
     {
         $tag = factory(Tag::class)->create(['name' => 'Test Tag']);


### PR DESCRIPTION
Addresses #321 
Also, if you look closely at #318, the failure was due to two whitespaces after "JSON".

### Current
Currently, the way the subject is checked DoesNotContainUrlRule is that the subject is "exploded" into an array, then each element is checked via:
```php
$validator->make(['word' => $value], ['word' => 'url'])->passes();
```
if the loop completes, with each element failing the 'url' check, then the custom rule passes.

### Problem
The problem is that if there is more than one space between words in the subject, some elements of the exploded subject will just be an empty string, which in this case passes ```['word' => 'url']``` validation. This in turn makes the custom rule fail.

### Goal
Honestly, I think you should consider adding some sanitization to your inputs, then we could avoid this fix. So if you don't want to pull this in, and address it closer to the beginning of the request, that's great as well.