### PR TITLE
Style error pages

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -3,8 +3,8 @@
 @extends('layouts.base', ['disableAds' => true])
 
 @section('body')
-    <div class="jumbotron text-center">
-        <h1>{{ $title }}</h1>
-        <p>You're not allowed to this page.</p>
+    <div class="my-20 text-center text-gray-800">
+        <h1 class="text-5xl">{{ $title }}</h1>
+        <p class="text-lg">You're not allowed to this page.</p>
     </div>
 @endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -3,8 +3,8 @@
 @extends('layouts.base', ['disableAds' => true])
 
 @section('body')
-    <div class="jumbotron text-center">
-        <h1>{{ $title }}</h1>
-        <p>The page you requested cannot be found.</p>
+    <div class="my-20 text-center text-gray-800">
+        <h1 class="text-5xl">{{ $title }}</h1>
+        <p class="text-lg">The page you requested cannot be found.</p>
     </div>
 @endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -3,11 +3,11 @@
 @extends('layouts.base', ['disableAds' => true])
 
 @section('body')
-    <div class="jumbotron text-center">
-        <h1>{{ $title }}</h1>
-        <p>
+    <div class="my-20 text-center text-gray-800">
+        <h1 class="text-5xl">{{ $title }}</h1>
+        <p class="text-lg">
             We've been notified and will try to fix the problem as soon as possible.<br>
-            Please <a href="https://github.com/laravelio/portal/issues/new">open a Github issue</a> if the problem persists.
+            Please <a href="https://github.com/laravelio/portal/issues/new" class="text-green-darker">open a Github issue</a> if the problem persists.
         </p>
     </div>
 @endsection


### PR DESCRIPTION
We could do something fun with these later down the line, but I think they work for now

<img width="1285" alt="Screenshot 2019-07-10 at 21 17 34" src="https://user-images.githubusercontent.com/3438564/61001848-529d4980-a358-11e9-9463-c6dd80adff1a.png">

<img width="1286" alt="Screenshot 2019-07-10 at 21 17 15" src="https://user-images.githubusercontent.com/3438564/61001849-529d4980-a358-11e9-9044-2ebd85a01e2a.png">

<img width="1287" alt="Screenshot 2019-07-10 at 21 16 51" src="https://user-images.githubusercontent.com/3438564/61001850-5335e000-a358-11e9-8951-ecc52e3f474f.png">
