### PR TITLE
swap hidden input for select

### DIFF
--- a/resources/js/components/MultiSelect.vue
+++ b/resources/js/components/MultiSelect.vue
@@ -10,14 +10,10 @@
             :close-on-select="false" 
             :clear-on-select="false" 
             :preserve-search="true"
+            @select="onSelect"
+            @remove="onRemove"
         />
-        <input 
-            v-for="value in values" 
-            type="hidden" 
-            :name="name" 
-            :value="value" 
-            :key="value"
-        />
+        <slot/>
     </div>
 </template>
 
@@ -26,16 +22,37 @@
     import 'vue-multiselect/dist/vue-multiselect.min.css';
 
     export default {
-        props: ['options', 'initialValue', 'label', 'trackBy', 'max', 'name'],
+        props: ['options', 'initialValue', 'label', 'trackBy', 'max', 'name', 'identifier'],
         components: { Multiselect },
         data() {
             return {
-                value: this.initialValue ? this.initialValue : []
+                value: this.initialValue ? this.initialValue : [],
+                selectElement: null,
+                selectOptions: [],
             }
+        },
+        mounted() {
+            this.selectElement = document.getElementById(this.identifier);
+            this.selectOptions = this.selectElement.options;
         },
         computed: {
             values() {
                 return this.value.map(value => { return value.id })
+            }
+        },
+        methods: {
+            onSelect(selectedOption) {
+                this.toggleSelected(selectedOption.id);                
+            },
+            onRemove(removedOption) {
+                this.toggleSelected(removedOption.id, false);                
+            },
+            toggleSelected(value, selected = true) {
+                Array.from(this.selectOptions).forEach(option => { 
+                    if(option.value == value) {
+                        option.selected = selected;
+                    }
+                });
             }
         }
     }

--- a/resources/views/forum/threads/_form.blade.php
+++ b/resources/views/forum/threads/_form.blade.php
@@ -21,7 +21,9 @@ e           :options="{{ $tags }}"
             placeholder="Choose up to 3 tags" 
             label="name" 
             track-by="name"
-            name="tags[]">
+            name="tags[]"
+            identifier="create-thread">
+            {!! Form::select('tags[]', $tags->pluck('name', 'id'), isset($thread) ? $thread->tags()->pluck('id')->toArray() : [], ['id' => 'create-thread', 'class' => 'hidden', 'multiple']) !!}
         </multi-select>
         @error('tags')
     @endFormGroup


### PR DESCRIPTION
This PR updates the multiselect to use a `<select>` element under the hood instead of hidden inputs.

This is better for accessibility and has the added bonus of fixing the broken tests.