### PR TITLE
Fix excerpt formatting

### DIFF
--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -32,7 +32,7 @@
                                         {{ count($thread->replies()) }}
                                     </span>
                                 </h4>
-                                <p class="text-gray-600">{{ $thread->excerpt() }}</p>
+                                <p class="text-gray-600">{!! $thread->excerpt() !!}</p>
                             </a>
                             <div class="flex flex-col md:flex-row md:items-center text-sm pt-5">
                                 <div class="flex mb-4 md:mb-0">


### PR DESCRIPTION
I don't like doing this, but in this instance, I think it's ok as the `excerpt` method utilises `strip_tags`.

```
public function excerpt(int $limit = 100): string
{
    return str_limit(strip_tags(md_to_html($this->body())), $limit);
}
```

This PR resolves #430 