### PR TITLE
Wrap text which overlaps container 

### DIFF
--- a/resources/css/threads.css
+++ b/resources/css/threads.css
@@ -10,6 +10,10 @@ div.thread-card:nth-last-child(2) {
     @apply border-b rounded-b;
 }
 
+div.forum-content {
+    @apply break-words;
+}
+
 div.forum-content div>* {
     @apply mb-4;
 }


### PR DESCRIPTION
Fixes #436 

![Screenshot 2019-09-18 at 07 48 59](https://user-images.githubusercontent.com/3438564/65122424-d757b400-d9e8-11e9-8667-4880b5dce30d.png)
