### PR TITLE
Highlight solved threads on overview

### DIFF
--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -69,6 +69,11 @@ final class Thread extends Model implements ReplyAble, SubscriptionAble
         return $this->belongsTo(Reply::class, 'solution_reply_id');
     }
 
+    public function isSolved(): bool
+    {
+        return ! is_null($this->solution_reply_id);
+    }
+
     public function isSolutionReply(Reply $reply): bool
     {
         if ($solution = $this->solutionReply()) {
@@ -139,10 +144,11 @@ final class Thread extends Model implements ReplyAble, SubscriptionAble
      */
     public static function feedQuery(): Builder
     {
-        return static::leftJoin('replies', function ($join) {
-            $join->on('threads.id', 'replies.replyable_id')
+        return static::with('solutionReplyRelation')
+            ->leftJoin('replies', function ($join) {
+                $join->on('threads.id', 'replies.replyable_id')
                     ->where('replies.replyable_type', static::TABLE);
-        })
+            })
             ->orderBy('latest_creation', 'DESC')
             ->groupBy('threads.id')
             ->select('threads.*', DB::raw('

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -34,27 +34,35 @@
                                 </h4>
                                 <p class="text-gray-600">{{ $thread->excerpt() }}</p>
                             </a>
-                            <div class="flex flex-col md:flex-row md:items-center text-sm pt-5">
-                                <div class="flex mb-4 md:mb-0">
-                                    @if (count($thread->replies()))
-                                        @include('forum.threads.info.avatar', ['user' => $thread->replies()->last()->author()])
-                                    @else
-                                        @include('forum.threads.info.avatar', ['user' => $thread->author()])
-                                    @endif
-
-                                    <div class="mr-6 text-gray-700">
+                            <div class="flex flex-col justify-between md:flex-row md:items-center text-sm pt-5">
+                                <div class="flex flex-col md:flex-row md:items-center">
+                                    <div class="flex mb-4 md:mb-0">
                                         @if (count($thread->replies()))
-                                            @php($lastReply = $thread->replies()->last())
-                                            <a href="{{ route('profile', $lastReply->author()->username()) }}" class="text-green-darker mr-2">{{ $lastReply->author()->name() }}</a> replied
-                                            {{ $lastReply->createdAt()->diffForHumans() }}
+                                            @include('forum.threads.info.avatar', ['user' => $thread->replies()->last()->author()])
                                         @else
-                                            <a href="{{ route('profile', $thread->author()->username()) }}" class="text-green-darker mr-2">{{ $thread->author()->name() }}</a> posted
-                                            {{ $thread->createdAt()->diffForHumans() }}
+                                            @include('forum.threads.info.avatar', ['user' => $thread->author()])
                                         @endif
+
+                                        <div class="mr-6 text-gray-700">
+                                            @if (count($thread->replies()))
+                                                @php($lastReply = $thread->replies()->last())
+                                                <a href="{{ route('profile', $lastReply->author()->username()) }}" class="text-green-darker mr-2">{{ $lastReply->author()->name() }}</a> replied
+                                                {{ $lastReply->createdAt()->diffForHumans() }}
+                                            @else
+                                                <a href="{{ route('profile', $thread->author()->username()) }}" class="text-green-darker mr-2">{{ $thread->author()->name() }}</a> posted
+                                                {{ $thread->createdAt()->diffForHumans() }}
+                                            @endif
+                                        </div>
                                     </div>
+                                    @include('forum.threads.info.tags')
                                 </div>
 
-                                @include('forum.threads.info.tags')
+                                @if ($thread->isSolved())
+                                    <a class="label label-primary text-center mt-4 md:mt-0" href="{{ route('thread', $thread->slug()) }}#{{ $thread->solutionReplyRelation->id }}">
+                                        <i class="fa fa-check mr-2"></i>
+                                        View solution
+                                    </a>
+                                @endif
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -43,7 +43,7 @@
                 </div>
 
                 @foreach ($thread->replies() as $reply)
-                    <div class="reply mt-8 bg-white rounded {{ $thread->isSolutionReply($reply) ? 'border-2 border-green-primary' : 'border' }}">
+                    <div class="reply mt-8 bg-white rounded {{ $thread->isSolutionReply($reply) ? 'border-2 border-green-primary' : 'border' }}" id="{{ $reply->id }}">
                         
                         @if ($thread->isSolutionReply($reply))
                             <div class="bg-green-primary text-white uppercase px-4 py-2 opacity-75">

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Models\Reply;
 use App\Models\Tag;
+use App\Models\Reply;
 use App\Models\Thread;
 use Tests\BrowserKitTestCase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Reply;
 use App\Models\Tag;
 use App\Models\Thread;
 use Tests\BrowserKitTestCase;
@@ -20,6 +21,22 @@ class ForumTest extends BrowserKitTestCase
         $this->visit('/forum')
             ->see('The first thread')
             ->see('The second thread');
+    }
+
+    /** @test */
+    public function users_can_see_when_a_thread_is_resolved()
+    {
+        factory(Thread::class)->create(['subject' => 'The first thread']);
+        $thread = factory(Thread::class)->create(['subject' => 'The second thread']);
+        $reply = factory(Reply::class)->create();
+        $thread->solutionReplyRelation()->associate($reply)->save();
+
+        $this->visit('/forum')
+            ->see('The first thread')
+            ->see('The second thread')
+            ->see('View solution')
+            ->click('View solution')
+            ->seeRouteIs('thread', ['thread' => $thread->slug()]);
     }
 
     /** @test */


### PR DESCRIPTION
This PR resolves #431 

It adds a visual indication on the forum overview page highlighting threads which have been resolved. Clicking `View solution` takes you directly to the accepted answer.

<img width="357" alt="Screenshot 2019-10-07 at 21 04 39" src="https://user-images.githubusercontent.com/3438564/66344661-4b311080-e946-11e9-8508-b3b560cc8fed.png">

<img width="939" alt="Screenshot 2019-10-07 at 21 03 34" src="https://user-images.githubusercontent.com/3438564/66344663-4b311080-e946-11e9-9a59-66c5da932784.png">
