### PR TITLE
Remove possibility of Vue error

### DIFF
--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -32,7 +32,7 @@
                                         {{ count($thread->replies()) }}
                                     </span>
                                 </h4>
-                                <p class="text-gray-600">{{ $thread->excerpt() }}</p>
+                                <p class="text-gray-600" v-pre>{{ $thread->excerpt() }}</p>
                             </a>
                             <div class="flex flex-col justify-between md:flex-row md:items-center text-sm pt-5">
                                 <div class="flex flex-col md:flex-row md:items-center">


### PR DESCRIPTION
If someone were to add a code snippet such as `{{ $foo }}` and this were output in the excerpt, Vue would interpret this as a valid expression and would throw an error.

Adding the `v-pre` directive tells Vue to ignore anything in the element.