### PR TITLE
Only allow alpha_dash characters for usernames resolves #460

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /public/mix-manifest.json
 /storage/*.key
 /vendor
+/laradock
 .env
 .phpunit.result.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "laradock"]
+	path = laradock
+	url = https://github.com/Laradock/laradock.git

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -16,7 +16,7 @@ class RegisterRequest extends FormRequest
         return [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
-            'username' => 'required|max:40|unique:users',
+            'username' => 'required|alpha_dash|max:40|unique:users',
             'rules' => 'accepted',
             'terms' => 'accepted',
             'github_id' => 'required',

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -11,7 +11,7 @@ class UpdateProfileRequest extends Request
         return [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users,email,'.Auth::id(),
-            'username' => 'required|max:255|unique:users,username,'.Auth::id(),
+            'username' => 'required|alpha_dash|max:255|unique:users,username,'.Auth::id(),
             'bio' => 'max:160',
         ];
     }

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -27,7 +27,9 @@
     @include('layouts._google_analytics')
     @include('layouts._ads._ad_sense')
     
-    @livewireAssets
+    {{-- @livewireAssets --}}
+    {{-- shows up in login page, dont know why this is here tho --}}
+
 </head>
 
 <body class="{{ $bodyClass ?? '' }} font-sans bg-white" x-data="{ activeModal: null }">


### PR DESCRIPTION
This PR  allow alpha_dash characters for usernames in profile settings and user registration.