### PR TITLE
Validate sort by fields

### DIFF
--- a/app/Http/Livewire/ShowArticles.php
+++ b/app/Http/Livewire/ShowArticles.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Livewire;
 
-use App\Models\Tag;
 use App\Models\Article;
-use Livewire\Component;
+use App\Models\Tag;
 use Illuminate\View\View;
+use Livewire\Component;
 use Livewire\WithPagination;
 
 final class ShowArticles extends Component

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use App\Models\Tag;
-use Livewire\Livewire;
-use App\Models\Article;
 use App\Http\Livewire\ShowArticles;
-use Tests\Feature\BrowserKitTestCase;
-use Illuminate\Support\Facades\Notification;
+use App\Models\Article;
+use App\Models\Tag;
 use App\Notifications\ArticleApprovedNotification;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\Feature\BrowserKitTestCase;
 
 uses(BrowserKitTestCase::class);
 uses(DatabaseMigrations::class);


### PR DESCRIPTION
We were using Livewire to validate the `sortBy` params when the buttons are clicked in the UI, but not if the query string was set manually on page load.