### PR TITLE
Replace default GitHub avatar

### DIFF
--- a/app/Console/Commands/BackfillIdenticons.php
+++ b/app/Console/Commands/BackfillIdenticons.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\UpdateUserIdenticonStatus;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class BackfillIdenticons extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:backfill-identicons';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Backfills the github_has_identicon column for users';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        User::whereNotNull('github_id')
+            ->chunk(100, function ($users) {
+                foreach ($users as $user) {
+                    UpdateUserIdenticonStatus::dispatch($user);
+                }
+
+                sleep(2);
+            });
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -71,9 +71,11 @@ class RegisterController extends Controller
     protected function create(RegisterRequest $request): User
     {
         $this->dispatchSync(RegisterUser::fromRequest($request));
+
         $user = User::findByEmailAddress($request->emailAddress());
+
         $this->dispatch(new UpdateUserIdenticonStatus($user));
 
-        return User::findByEmailAddress($request->emailAddress());
+        return $user;
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -16,7 +16,7 @@ class HomeController extends Controller
         $communityMembers = Cache::remember(
             'communityMembers',
             now()->addMinutes(5),
-            fn () => User::notBanned()->inRandomOrder()->take(100)->get()->chunk(20)
+            fn () => User::notBanned()->withAvatar()->inRandomOrder()->take(100)->get()->chunk(20)
         );
 
         $totalUsers = Cache::remember('totalUsers', now()->addDay(), fn () => number_format(User::notBanned()->count()));

--- a/app/Jobs/UnVerifyAuthor.php
+++ b/app/Jobs/UnVerifyAuthor.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
-class UnVerifyAuthor implements ShouldQueue
+final class UnVerifyAuthor implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Jobs/UpdateUserIdenticonStatus.php
+++ b/app/Jobs/UpdateUserIdenticonStatus.php
@@ -14,11 +14,12 @@ final class UpdateUserIdenticonStatus implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public function __construct(private User $user) {}
+    public function __construct(protected User $user) {}
 
     public function handle(GithubUserApi $github): void
     {
         $hasIdenticon = $github->hasIdenticon($this->user->githubId());
-        $this->user->update(['has_identicon' => $hasIdenticon]);
+
+        $this->user->update(['github_has_identicon' => $hasIdenticon]);
     }
 }

--- a/app/Jobs/VerifyAuthor.php
+++ b/app/Jobs/VerifyAuthor.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
-class VerifyAuthor implements ShouldQueue
+final class VerifyAuthor implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -58,7 +58,7 @@ final class User extends Authenticatable implements MustVerifyEmail
         'remember_token',
         'bio',
         'banned_reason',
-        'has_identicon'
+        'github_has_identicon'
     ];
 
     /**
@@ -76,6 +76,7 @@ final class User extends Authenticatable implements MustVerifyEmail
         return [
             'allowed_notifications' => 'array',
             'author_verified_at' => 'datetime',
+            'github_has_identicon' => 'boolean',
         ];
     }
 
@@ -116,7 +117,7 @@ final class User extends Authenticatable implements MustVerifyEmail
 
     public function hasIdenticon(): bool
     {
-        return (bool) $this->has_identicon;
+        return (bool) $this->github_has_identicon;
     }
 
     public function twitter(): ?string
@@ -415,6 +416,11 @@ final class User extends Authenticatable implements MustVerifyEmail
             self::ADMIN,
             self::MODERATOR,
         ]);
+    }
+
+    public function scopeWithAvatar(Builder $query)
+    {
+        return $query->where('github_has_identicon', false);
     }
 
     public function scopeNotBanned(Builder $query)

--- a/app/Social/GithubUserApi.php
+++ b/app/Social/GithubUserApi.php
@@ -5,7 +5,7 @@ namespace App\Social;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
-class GithubUserApi
+final class GithubUserApi
 {
     public function find(int|string $id): ?GitHubUser
     {
@@ -17,22 +17,19 @@ class GithubUserApi
 
     public function hasIdenticon(int|string $id): bool
     {
-        $detectionSize = 40;
         $response = Http::retry(3, 300, fn ($exception) => $exception instanceof ConnectionException)
-            ->get("https://avatars.githubusercontent.com/u/{$id}?v=4&s={$detectionSize}");
+            ->get("https://avatars.githubusercontent.com/u/{$id}?v=4&s=40");
 
         if ($response->failed()) {
             return true;
         }
 
-        $info = getimagesizefromstring($response->body());
-
-        if (!$info) {
+        if (! $info = getimagesizefromstring($response->body())) {
             return true;
         }
 
         [$width, $height] = $info;
 
-        return !($width === 420 && $height === 420);
+        return ! ($width === 420 && $height === 420);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,6 +23,7 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
             'github_id' => $this->faker->unique()->numberBetween(10000, 99999),
             'github_username' => $this->faker->unique()->userName(),
+            'github_has_identicon' => $this->faker->boolean(),
             'twitter' => $this->faker->unique()->userName(),
             'bluesky' => $this->faker->unique()->userName(),
             'website' => 'https://laravel.io',

--- a/database/migrations/2025_09_11_152525_add_has_identicon_to_users_table.php
+++ b/database/migrations/2025_09_11_152525_add_has_identicon_to_users_table.php
@@ -9,8 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->boolean('has_identicon')->after('bio')->default(false);
+            $table->boolean('github_has_identicon')->after('github_username')->default(false);
         });
     }
-
 };

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -34,7 +34,7 @@ class UserSeeder extends Seeder
         DB::beginTransaction();
 
         User::factory()
-            ->count(100)
+            ->count(300)
             ->has(Thread::factory()->count(2), 'threadsRelation')
             ->has(
                 Article::factory()

--- a/resources/views/components/avatar.blade.php
+++ b/resources/views/components/avatar.blade.php
@@ -4,7 +4,7 @@
 ])
 
 <?php
-$src = $user->githubId() && !$user->hasIdenticon()
+$src = $user->githubId() && ! $user->hasIdenticon()
     ? sprintf('https://avatars.githubusercontent.com/u/%s', $user->githubId())
     : asset('https://laravel.io/images/laravelio-icon-gray.svg');
 ?>


### PR DESCRIPTION
Solves #688 
- Added a new user field: has_identicon, calculated through an async job dispatched at user signup.
- Used has_identicon field in the avatar component to decide the picture to be shown.
Note: The only existing GitHub test (GitHubUserTest.php) doesn’t cover HTTP requests. My contribution depends on the HTTP client bootstrap, so adding tests would require extra Pest setup I wasn’t sure to include.

Final view of some users created through the local tests:
<img width="1634" height="728" alt="image" src="https://github.com/user-attachments/assets/dbbdde77-21ea-42b5-949e-d579630738c9" />