### PR TITLE
feat: add Unsplash image search for article hero images

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,15 @@ FATHOM_TOKEN=
 
 ### Unsplash (optional)
 
-To make sure article and user header images get synced into the database we'll need to setup an access key from [Unsplash](https://unsplash.com/developers). Please note that your Unsplash app requires production access.
+To enable article hero image search and syncing, you'll need to set up an access key from [Unsplash](https://unsplash.com/developers). Please note that your Unsplash app requires production access.
 
 ```
 UNSPLASH_ACCESS_KEY=
 ```
 
-After that you can add an Unsplash photo ID to any article row in the `hero_image_id` column and run the sync command to fetch the image url and author data:
+Authors can search for landscape Unsplash images from the article create/edit form. The selected image is stored as an Unsplash photo ID in the `hero_image_id` column.
 
-```bash
-php artisan lio:sync-article-images
-```
+When an article is created or updated with a hero image, Laravel.io dispatches the `SyncArticleImage` job. This job fetches the photo metadata from Unsplash, stores the raw image URL and photographer attribution data on the article, and calls the Unsplash download endpoint to register the photo usage.
 
 ## Commands
 

--- a/app/Exceptions/UnsplashRequestFailed.php
+++ b/app/Exceptions/UnsplashRequestFailed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+final class UnsplashRequestFailed extends Exception
+{
+    //
+}

--- a/app/Jobs/SyncArticleImage.php
+++ b/app/Jobs/SyncArticleImage.php
@@ -2,13 +2,14 @@
 
 namespace App\Jobs;
 
+use App\Exceptions\UnsplashRequestFailed;
 use App\Models\Article;
+use App\UnsplashClient;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Http;
 
 final class SyncArticleImage implements ShouldQueue
 {
@@ -19,42 +20,25 @@ final class SyncArticleImage implements ShouldQueue
         //
     }
 
-    public function handle(): void
+    public function handle(UnsplashClient $unsplash): void
     {
-        $imageData = $this->fetchUnsplashImageDataFromId($this->article);
+        if (! $this->article->hero_image_id) {
+            return;
+        }
 
-        if (! is_null($imageData)) {
-            $this->article->hero_image_url = $imageData['image_url'];
-            $this->article->hero_image_author_name = $imageData['author_name'];
-            $this->article->hero_image_author_url = $imageData['author_url'];
+        try {
+            $photo = $unsplash->findPhoto($this->article->hero_image_id);
+            $unsplash->downloadPhoto($photo['links']['download_location']);
+        } catch (UnsplashRequestFailed) {
+            $this->article->hero_image_id = null;
             $this->article->save();
-        }
-    }
 
-    protected function fetchUnsplashImageDataFromId(Article $article): ?array
-    {
-        $response = Http::retry(3, 100, throw: false)
-            ->withToken(config('services.unsplash.access_key'), 'Client-ID')
-            ->get("https://api.unsplash.com/photos/{$article->hero_image_id}");
-
-        if ($response->failed()) {
-            $article->hero_image_id = null;
-            $article->save();
-
-            return null;
+            return;
         }
 
-        $response = $response->json();
-
-        // Trigger as Unsplash download...
-        Http::retry(3, 100, throw: false)
-            ->withToken(config('services.unsplash.access_key'), 'Client-ID')
-            ->get($response['links']['download_location']);
-
-        return [
-            'image_url' => $response['urls']['raw'],
-            'author_name' => $response['user']['name'],
-            'author_url' => $response['user']['links']['html'],
-        ];
+        $this->article->hero_image_url = $photo['urls']['raw'];
+        $this->article->hero_image_author_name = $photo['user']['name'];
+        $this->article->hero_image_author_url = $photo['user']['links']['html'];
+        $this->article->save();
     }
 }

--- a/app/Livewire/ArticleHeroImagePicker.php
+++ b/app/Livewire/ArticleHeroImagePicker.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Exceptions\UnsplashRequestFailed;
+use App\Models\Article;
+use App\UnsplashClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+use Livewire\Component;
+
+final class ArticleHeroImagePicker extends Component
+{
+    private const MIN_QUERY_LENGTH = 3;
+
+    protected UnsplashClient $unsplash;
+
+    public int $minimumQueryLength = self::MIN_QUERY_LENGTH;
+
+    public string $query = '';
+
+    public ?string $selectedImageId = null;
+
+    public ?array $selectedImage = null;
+
+    public array $images = [];
+
+    public bool $isOpen = false;
+
+    public ?string $error = null;
+
+    public bool $hasSearched = false;
+
+    public bool $isVerifiedAuthor = false;
+
+    public int $page = 1;
+
+    public int $totalPages = 1;
+
+    public bool $isLoadingMore = false;
+
+    public function boot(UnsplashClient $unsplash): void
+    {
+        $this->unsplash = $unsplash;
+    }
+
+    public function mount(?Article $article = null): void
+    {
+        $author = $article?->exists ? $article->author() : auth()->user();
+
+        $this->isVerifiedAuthor = $author?->isVerifiedAuthor() ?? false;
+
+        $this->selectedImageId = old('hero_image_id', $article?->hero_image_id);
+
+        if ($article?->hero_image_id && $article?->hero_image_url) {
+            $this->selectedImage = [
+                'id' => $article->hero_image_id,
+                'raw_url' => $article->hero_image_url,
+                'author_name' => $article->hero_image_author_name,
+                'author_url' => $article->hero_image_author_url,
+            ];
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.article-hero-image-picker');
+    }
+
+    public function updatedQuery(): void
+    {
+        $query = Str::of($this->query)->squish()->toString();
+
+        if (strlen($query) < self::MIN_QUERY_LENGTH) {
+            $this->resetSearch();
+
+            return;
+        }
+
+        $this->startSearch();
+        $this->page = 1;
+
+        if (is_array($cachedResponse = Cache::get($cacheKey = $this->cacheKey($query, $this->page)))) {
+            $this->images = $this->mapImages($cachedResponse);
+            $this->totalPages = $cachedResponse['total_pages'] ?? 1;
+            $this->finishSearch(resetScroll: true);
+
+            return;
+        }
+
+        try {
+            $response = $this->unsplash->searchPhotos($query, $this->page);
+
+            $this->images = $this->mapImages($response);
+            $this->totalPages = $response['total_pages'] ?? 1;
+        } catch (UnsplashRequestFailed) {
+            $this->images = [];
+            $this->error = 'We could not load images from Unsplash. Please try again.';
+        }
+
+        if ($this->error === null) {
+            Cache::put($cacheKey, $response, $this->cacheDuration());
+        }
+
+        $this->finishSearch(resetScroll: true);
+    }
+
+    public function loadMore(): void
+    {
+        if (! $this->canLoadMore() || $this->isLoadingMore) {
+            return;
+        }
+
+        $this->isLoadingMore = true;
+
+        try {
+            $query = Str::of($this->query)->squish()->toString();
+            $nextPage = $this->page + 1;
+            $cacheKey = $this->cacheKey($query, $nextPage);
+
+            if (is_array($cachedResponse = Cache::get($cacheKey))) {
+                $this->page = $nextPage;
+                $this->totalPages = $cachedResponse['total_pages'] ?? $this->totalPages;
+                $this->images = [...$this->images, ...$this->mapImages($cachedResponse)];
+
+                return;
+            }
+
+            $response = $this->unsplash->searchPhotos($query, $nextPage);
+
+            $this->page = $nextPage;
+            $this->totalPages = $response['total_pages'] ?? $this->totalPages;
+            $this->images = [...$this->images, ...$this->mapImages($response)];
+
+            Cache::put($cacheKey, $response, $this->cacheDuration());
+        } catch (UnsplashRequestFailed) {
+            $this->error = 'We could not load more images from Unsplash. Please try again.';
+        } finally {
+            $this->isLoadingMore = false;
+        }
+    }
+
+    public function canLoadMore(): bool
+    {
+        return $this->hasSearched && $this->error === null && $this->page < $this->totalPages;
+    }
+
+    public function selectImage(string $imageId): void
+    {
+        $image = collect($this->images)->firstWhere('id', $imageId);
+
+        if (! $image) {
+            return;
+        }
+
+        $this->selectedImageId = $image['id'];
+        $this->selectedImage = $image;
+        $this->query = '';
+        $this->resetSearch();
+    }
+
+    public function removeImage(): void
+    {
+        $this->selectedImageId = null;
+        $this->selectedImage = null;
+    }
+
+    public function previewImageUrl(string $url, int $width = 200): string
+    {
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return "{$url}{$separator}fit=max&w={$width}";
+    }
+
+    public function unsplashUrl(): string
+    {
+        return 'https://unsplash.com/?utm_source=Laravel.io&utm_medium=referral';
+    }
+
+    public function authorUrl(string $url): string
+    {
+        return "{$url}?utm_source=Laravel.io&utm_medium=referral";
+    }
+
+    private function resetSearch(): void
+    {
+        $this->images = [];
+        $this->isOpen = false;
+        $this->error = null;
+        $this->hasSearched = false;
+        $this->page = 1;
+        $this->totalPages = 1;
+        $this->isLoadingMore = false;
+    }
+
+    private function startSearch(): void
+    {
+        $this->isOpen = true;
+        $this->error = null;
+        $this->hasSearched = false;
+    }
+
+    private function finishSearch(bool $resetScroll = false): void
+    {
+        $this->hasSearched = true;
+
+        if ($resetScroll) {
+            $this->dispatch('unsplash-images-updated');
+        }
+    }
+
+    private function cacheKey(string $query, int $page): string
+    {
+        return 'unsplash-search:'.md5(Str::lower($query)).":page:{$page}";
+    }
+
+    private function cacheDuration(): \DateTimeInterface
+    {
+        return now()->addHours(6);
+    }
+
+    private function mapImages(array $response): array
+    {
+        return collect($response['results'] ?? [])
+            ->map(fn (array $image) => [
+                'id' => $image['id'],
+                'raw_url' => $image['urls']['raw'],
+                'thumb_url' => $image['urls']['thumb'],
+                'author_name' => $image['user']['name'],
+                'author_url' => $image['user']['links']['html'],
+            ])
+            ->all();
+    }
+}

--- a/app/UnsplashClient.php
+++ b/app/UnsplashClient.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App;
+
+use App\Exceptions\UnsplashRequestFailed;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+final class UnsplashClient
+{
+    private const string API_URL = 'https://api.unsplash.com';
+
+    private PendingRequest $http;
+
+    public function __construct()
+    {
+        $this->http = Http::retry(3, 100, throw: false)
+            ->timeout(10)
+            ->connectTimeout(3)
+            ->withToken(config('services.unsplash.access_key'), 'Client-ID');
+    }
+
+    /**
+     * @throws \App\Exceptions\UnsplashRequestFailed
+     */
+    public function searchPhotos(string $query, int $page = 1): array
+    {
+        $response = $this->http->get(self::API_URL.'/search/photos', [
+            'query' => $query,
+            'page' => $page,
+            'per_page' => 12,
+            'orientation' => 'landscape',
+            'content_filter' => 'high',
+        ]);
+
+        if ($response->failed()) {
+            throw new UnsplashRequestFailed;
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * @throws \App\Exceptions\UnsplashRequestFailed
+     */
+    public function findPhoto(string $id): array
+    {
+        $response = $this->http->get(self::API_URL."/photos/{$id}");
+
+        if ($response->failed()) {
+            throw new UnsplashRequestFailed;
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * @throws \App\Exceptions\UnsplashRequestFailed
+     */
+    public function downloadPhoto(string $location): void
+    {
+        $response = $this->http->get($location);
+
+        if ($response->failed()) {
+            throw new UnsplashRequestFailed;
+        }
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -32,6 +32,23 @@
   }
 }
 
+@layer utilities {
+    .scroll-fade {
+        --scroll-fade-size: 10px;
+        mask-image: linear-gradient(
+            to bottom,
+            transparent,
+            black var(--scroll-fade-size),
+            black calc(100% - var(--scroll-fade-size)),
+            transparent
+        );
+    }
+
+    .scroll-fade-none {
+        mask-image: none;
+    }
+}
+
 @theme {
     --font-sans: Inter, sans-serif;
 }

--- a/resources/views/components/articles/form.blade.php
+++ b/resources/views/components/articles/form.blade.php
@@ -52,21 +52,7 @@
                 <div class="space-y-1">
                     <x-forms.label for="hero_image_id">Hero Image</x-forms.label>
 
-                    <x-forms.inputs.input name="hero_image_id" :value="$article?->hero_image_id" maxlength="20" placeholder="NoiJZhDF4Es" />
-
-                    @if (($article?->author() ?? auth()->user())->isVerifiedAuthor())
-                        <p class="mt-2 text-sm text-gray-600">
-                            Because you're a verified author, you're required to choose an <x-a href="https://unsplash.com/s/photos/hello?orientation=landscape" >Unsplash</x-a> image for your article.
-                        </p>
-                    @else
-                        <p class="mt-2 text-sm text-gray-600">
-                            Optionally, add an <x-a href="https://unsplash.com/s/photos/hello?orientation=landscape">Unsplash</x-a> image.
-                        </p>
-                    @endif
-
-                    <p class="mt-2 text-sm text-gray-600">
-                        Please enter the Unsplash ID of the image you want to use. <strong>You can find the ID in the URL of the image on Unsplash</strong>. Please make sure to <strong>only use landscape images</strong>. For example, if the URL is <code class="whitespace-nowrap">https://unsplash.com/photos/...-NoiJZhDF4Es</code>, then the ID is <code>NoiJZhDF4Es</code>. After saving your article, the image will be automatically fetched and displayed in the article. This might take a few minutes. If you want to change the image later, you can do so by editing the article before submitting it for approval.
-                    </p>
+                    <livewire:article-hero-image-picker :article="$article" />
                 </div>
             </div>
 

--- a/resources/views/livewire/article-hero-image-picker.blade.php
+++ b/resources/views/livewire/article-hero-image-picker.blade.php
@@ -1,0 +1,141 @@
+<div class="space-y-4">
+    <input type="hidden" name="hero_image_id" value="{{ $selectedImageId }}">
+
+    <div
+        class="relative"
+        x-data="{
+            open: @entangle('isOpen'),
+            resetScroll() {
+                this.$nextTick(() => this.$refs.images?.scrollTo({ top: 0 }))
+            },
+        }"
+        x-effect="if (open) resetScroll()"
+        @unsplash-images-updated.window="resetScroll()"
+        @click.outside="open = false"
+    >
+        <x-forms.inputs.input
+            type="search"
+            name="hero_image_search"
+            wire:model.live.debounce.500ms="query"
+            placeholder="Search landscape photos on Unsplash"
+            autocomplete="off"
+            prefix-icon="heroicon-o-magnifying-glass"
+            @input="open = $event.target.value.trim().length >= {{ $minimumQueryLength }}"
+            @focus="open = $event.target.value.trim().length >= {{ $minimumQueryLength }} || {{ count($images) > 0 || $error ? 'true' : 'false' }}"
+        />
+
+        <div
+            x-cloak
+            x-show="open"
+            class="absolute left-0 z-20 mt-2 w-full max-w-md overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5"
+        >
+            <div wire:loading wire:target="query" class="p-4 text-sm text-gray-600">
+                Searching Unsplash images...
+            </div>
+
+            <div wire:loading.remove wire:target="query">
+                @if ($error)
+                    <div class="p-4 text-sm text-red-600">
+                        {{ $error }}
+                    </div>
+                @elseif (count($images) > 0)
+                    <div x-ref="images" class="scroll-fade grid max-h-72 grid-cols-2 gap-2 overflow-y-auto p-2">
+                            @foreach ($images as $image)
+                                <div wire:key="unsplash-image-{{ $image['id'] }}" class="overflow-hidden rounded-md border border-gray-200 bg-white transition hover:border-lio-400">
+                                    <button
+                                        type="button"
+                                        wire:click="selectImage('{{ $image['id'] }}')"
+                                        class="group block w-full text-left focus:outline-hidden focus:ring-3 focus:ring-lio-200"
+                                    >
+                                        <img
+                                            src="{{ $image['thumb_url'] }}"
+                                            alt="Unsplash photo by {{ $image['author_name'] }}"
+                                            class="aspect-video w-full object-cover"
+                                        >
+                                    </button>
+
+                                    <span class="block truncate px-2 py-1 text-xs text-gray-600">
+                                        Photo by
+                                        <a
+                                            href="{{ $this->authorUrl($image['author_url']) }}"
+                                            class="font-medium text-lio-700"
+                                            target="_blank"
+                                            rel="nofollow noopener noreferrer"
+                                            @click.stop
+                                        >
+                                            {{ $image['author_name'] }}
+                                        </a>
+                                    </span>
+                                </div>
+                            @endforeach
+
+                            @if ($this->canLoadMore())
+                                <div
+                                    x-intersect="$wire.loadMore()"
+                                    class="col-span-2 h-px"
+                                ></div>
+                            @endif
+                    </div>
+
+                    <p class="border-t border-gray-100 px-3 py-2 text-xs text-gray-500">
+                        Photos provided by <a href="{{ $this->unsplashUrl() }}" class="font-medium text-lio-700" target="_blank" rel="nofollow noopener noreferrer">Unsplash</a>.
+                    </p>
+                @elseif ($hasSearched)
+                    <div class="p-4 text-sm text-gray-600">
+                        No images found.
+                    </div>
+                @else
+                    <div class="p-4 text-sm text-gray-600">
+                        Preparing search...
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    @if ($errors->has('hero_image_id'))
+        @foreach ($errors->get('hero_image_id') as $error)
+            <x-forms.error>{{ $error }}</x-forms.error>
+        @endforeach
+    @endif
+
+    <div class="space-y-2">
+        @if ($isVerifiedAuthor)
+            <p class="text-sm text-gray-600">
+                Because you're a verified author, you're required to choose an <x-a href="https://unsplash.com/s/photos/hello?orientation=landscape" >Unsplash</x-a> image for your article.
+            </p>
+        @else
+            <p class="text-sm text-gray-600">
+                Optionally, add an <x-a href="https://unsplash.com/s/photos/hello?orientation=landscape">Unsplash</x-a> image.
+            </p>
+        @endif
+
+        <p class="text-sm text-gray-600">
+            Search and choose a landscape image from Unsplash. After saving your article, the image will be automatically fetched and displayed in the article. This might take a few minutes. If you want to change the image later, you can do so by editing the article before submitting it for approval.
+        </p>
+    </div>
+
+    @if ($selectedImage)
+        <div class="inline-block overflow-hidden rounded-md border border-gray-200 bg-white">
+            <img
+                src="{{ $this->previewImageUrl($selectedImage['raw_url'], 400) }}"
+                alt="Unsplash photo by {{ $selectedImage['author_name'] }}"
+                class="block h-auto max-w-full"
+            >
+
+            <div class="flex items-center justify-between gap-4 px-4 py-3">
+                <p class="truncate text-sm text-gray-600">
+                    Photo by
+                    <a href="{{ $this->authorUrl($selectedImage['author_url']) }}" class="font-medium text-lio-700" target="_blank" rel="nofollow noopener noreferrer">
+                        {{ $selectedImage['author_name'] }}
+                    </a>
+                    on <a href="{{ $this->unsplashUrl() }}" class="font-medium text-lio-700" target="_blank" rel="nofollow noopener noreferrer">Unsplash</a>
+                </p>
+
+                <button type="button" wire:click="removeImage" class="shrink-0 cursor-pointer text-sm text-lio-700">
+                    Remove
+                </button>
+            </div>
+        </div>
+    @endif
+</div>

--- a/tests/Feature/ArticleHeroImagePickerTest.php
+++ b/tests/Feature/ArticleHeroImagePickerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Livewire\ArticleHeroImagePicker;
+use App\Models\Article;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('it searches unsplash images', function () {
+    Config::set('services.unsplash.access_key', 'test');
+
+    Cache::shouldReceive('get')
+        ->once()
+        ->with(unsplashSearchCacheKey('coffee', 1))
+        ->andReturn(null);
+    Cache::shouldReceive('put')->once()->andReturnTrue();
+
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response(fixture('Unsplash/search-photos.json')),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->assertSet('isOpen', true)
+        ->assertSet('hasSearched', true)
+        ->assertSet('page', 1)
+        ->assertSet('totalPages', 7)
+        ->assertDispatched('unsplash-images-updated')
+        ->assertSee('Jeff Sheldon');
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.unsplash.com/search/photos?query=coffee&page=1&per_page=12&orientation=landscape&content_filter=high'
+            && $request->hasHeader('Authorization', 'Client-ID test');
+    });
+});
+
+test('it loads more unsplash images', function () {
+    Cache::shouldReceive('get')
+        ->twice()
+        ->andReturn(null, null);
+    Cache::shouldReceive('put')->twice()->andReturnTrue();
+
+    Http::fake([
+        'api.unsplash.com/search/photos?query=coffee&page=1&per_page=12&orientation=landscape&content_filter=high' => Http::response(fixture('Unsplash/search-photos.json')),
+        'api.unsplash.com/search/photos?query=coffee&page=2&per_page=12&orientation=landscape&content_filter=high' => Http::response(fixture('Unsplash/search-photos-page-2.json')),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->assertSet('page', 1)
+        ->assertSet('totalPages', 7)
+        ->assertSet('isLoadingMore', false)
+        ->call('loadMore')
+        ->assertSet('page', 2)
+        ->assertSet('totalPages', 7)
+        ->assertSet('isLoadingMore', false)
+        ->assertSee('Jeff Sheldon')
+        ->assertSee('Annie Spratt');
+
+    Http::assertSentCount(2);
+});
+
+test('it caches each unsplash search page', function () {
+    Cache::shouldReceive('get')
+        ->times(4)
+        ->andReturn(
+            null,
+            null,
+            fixture('Unsplash/search-photos.json'),
+            fixture('Unsplash/search-photos-page-2.json'),
+        );
+    Cache::shouldReceive('put')->twice()->andReturnTrue();
+
+    Http::fake([
+        'api.unsplash.com/search/photos?query=coffee&page=1&per_page=12&orientation=landscape&content_filter=high' => Http::response(fixture('Unsplash/search-photos.json')),
+        'api.unsplash.com/search/photos?query=coffee&page=2&per_page=12&orientation=landscape&content_filter=high' => Http::response(fixture('Unsplash/search-photos-page-2.json')),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->call('loadMore');
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->call('loadMore');
+
+    Http::assertSentCount(2);
+});
+
+test('it does not search unsplash until the query has three characters', function () {
+    Http::fake();
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'co')
+        ->assertSet('isOpen', false)
+        ->assertSet('hasSearched', false);
+
+    Http::assertNothingSent();
+});
+
+test('it caches unsplash searches', function () {
+    Cache::shouldReceive('get')
+        ->twice()
+        ->andReturn(null, fixture('Unsplash/search-photos.json'));
+    Cache::shouldReceive('put')->once()->andReturnTrue();
+
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response(fixture('Unsplash/search-photos.json')),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)->set('query', 'coffee');
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->assertDispatched('unsplash-images-updated');
+
+    Http::assertSentCount(1);
+});
+
+test('it shows an error when unsplash cannot be reached', function () {
+    Cache::shouldReceive('get')
+        ->once()
+        ->with(unsplashSearchCacheKey('coffee', 1))
+        ->andReturn(null);
+    Cache::shouldReceive('put')->never();
+
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response([], 500),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->assertSet('isOpen', true)
+        ->assertSet('hasSearched', true)
+        ->assertSee('We could not load images from Unsplash. Please try again.');
+});
+
+test('it selects an unsplash image', function () {
+    Cache::shouldReceive('get')
+        ->once()
+        ->with(unsplashSearchCacheKey('coffee', 1))
+        ->andReturn(null);
+    Cache::shouldReceive('put')->once()->andReturnTrue();
+
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response(fixture('Unsplash/search-photos.json')),
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class)
+        ->set('query', 'coffee')
+        ->call('selectImage', 'eOLpJytrbsQ')
+        ->assertSet('selectedImageId', 'eOLpJytrbsQ')
+        ->assertSet('query', '')
+        ->assertSet('images', [])
+        ->assertSet('hasSearched', false)
+        ->assertSet('isOpen', false)
+        ->assertSee('Photo by')
+        ->assertSee('Jeff Sheldon')
+        ->assertSee('Unsplash');
+});
+
+test('it renders an existing article image', function () {
+    $article = new Article([
+        'hero_image_id' => 'eOLpJytrbsQ',
+        'hero_image_url' => 'https://images.unsplash.com/photo-1416339306562-f3d12fefd36f',
+        'hero_image_author_name' => 'Jeff Sheldon',
+        'hero_image_author_url' => 'https://unsplash.com/@ugmonk',
+    ]);
+
+    Livewire::test(ArticleHeroImagePicker::class, ['article' => $article])
+        ->assertSet('selectedImageId', 'eOLpJytrbsQ')
+        ->assertSee('Jeff Sheldon');
+});
+
+function unsplashSearchCacheKey(string $query, int $page): string
+{
+    return 'unsplash-search:'.md5(strtolower($query)).":page:{$page}";
+}

--- a/tests/Fixtures/Unsplash/photo.json
+++ b/tests/Fixtures/Unsplash/photo.json
@@ -1,0 +1,79 @@
+{
+    "id": "eOLpJytrbsQ",
+    "created_at": "2016-05-03T11:00:28-04:00",
+    "updated_at": "2016-07-10T11:00:01-05:00",
+    "width": 2448,
+    "height": 3264,
+    "color": "#6E633A",
+    "blur_hash": "LFC$yHwc8^$yIAS$%M%00KxukYIp",
+    "downloads": 1345,
+    "public_domain": false,
+    "description": "A man drinking a coffee.",
+    "exif": {
+        "make": "Canon",
+        "model": "Canon EOS 40D",
+        "name": "Canon, EOS 40D",
+        "exposure_time": "0.011111111111111112",
+        "aperture": "4.970854",
+        "focal_length": "37",
+        "iso": 100
+    },
+    "location": {
+        "city": "Montreal",
+        "country": "Canada",
+        "position": {
+            "latitude": 45.473298,
+            "longitude": -73.638488
+        }
+    },
+    "tags": [
+        {
+            "title": "man"
+        },
+        {
+            "title": "drinking"
+        },
+        {
+            "title": "coffee"
+        }
+    ],
+    "current_user_collections": [
+        {
+            "id": 206,
+            "title": "Makers: Cat and Ben",
+            "published_at": "2016-01-12T18:16:09-05:00",
+            "last_collected_at": "2016-06-02T13:10:03-04:00",
+            "updated_at": "2016-07-10T11:00:01-05:00",
+            "cover_photo": null,
+            "user": null
+        }
+    ],
+    "links": {
+        "self": "https://api.unsplash.com/photos/eOLpJytrbsQ",
+        "html": "https://unsplash.com/photos/eOLpJytrbsQ",
+        "download": "https://unsplash.com/photos/eOLpJytrbsQ/download",
+        "download_location": "https://api.unsplash.com/photos/eOLpJytrbsQ/download"
+    },
+    "urls": {
+        "raw": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f",
+        "full": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?q=75&fm=jpg",
+        "regular": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?q=75&fm=jpg&w=1080&fit=max",
+        "small": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?q=75&fm=jpg&w=400&fit=max",
+        "thumb": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?q=75&fm=jpg&w=200&fit=max"
+    },
+    "user": {
+        "id": "QPxL2MGqfrw",
+        "updated_at": "2016-07-10T11:00:01-05:00",
+        "username": "ugmonk",
+        "name": "Jeff Sheldon",
+        "portfolio_url": "https://example.com/",
+        "bio": "Just an everyday Joe",
+        "location": "Montreal",
+        "total_collections": 13,
+        "links": {
+            "self": "https://api.unsplash.com/users/ugmonk",
+            "html": "https://unsplash.com/@ugmonk",
+            "photos": "https://api.unsplash.com/users/ugmonk/photos"
+        }
+    }
+}

--- a/tests/Fixtures/Unsplash/search-photos-page-2.json
+++ b/tests/Fixtures/Unsplash/search-photos-page-2.json
@@ -1,0 +1,49 @@
+{
+    "total": 133,
+    "total_pages": 7,
+    "results": [
+        {
+            "id": "gKXKBY-C-Dk",
+            "created_at": "2017-04-05T15:12:01-04:00",
+            "width": 5184,
+            "height": 3456,
+            "color": "#59734a",
+            "blur_hash": "LIDm%2D%M{t7~qM|t7Rj-;M{Rjof",
+            "description": "Green leaves with sunlight.",
+            "alt_description": "Green leaves with sunlight.",
+            "user": {
+                "id": "IFcEhJqem0Q",
+                "username": "anniespratt",
+                "name": "Annie Spratt",
+                "first_name": "Annie",
+                "last_name": "Spratt",
+                "instagram_username": "anniespratt",
+                "twitter_username": "anniespratt",
+                "portfolio_url": "https://anniespratt.com/",
+                "profile_image": {
+                    "small": "https://images.unsplash.com/profile-1455807367298-3fe1038e4b88?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=e4b7359d04d963abccffef8c4b7b707c",
+                    "medium": "https://images.unsplash.com/profile-1455807367298-3fe1038e4b88?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=d4dd8903e397d93f95e5503aab39f8e4",
+                    "large": "https://images.unsplash.com/profile-1455807367298-3fe1038e4b88?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=a7d32db26663f003f98fc68fb6266e67"
+                },
+                "links": {
+                    "self": "https://api.unsplash.com/users/anniespratt",
+                    "html": "http://unsplash.com/@anniespratt",
+                    "photos": "https://api.unsplash.com/users/anniespratt/photos"
+                }
+            },
+            "current_user_collections": [],
+            "urls": {
+                "raw": "https://images.unsplash.com/photo-1473081556163-2a17de81fc97",
+                "full": "https://hd.unsplash.com/photo-1473081556163-2a17de81fc97",
+                "regular": "https://images.unsplash.com/photo-1473081556163-2a17de81fc97?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=f16b032d23285c638a281ab9d6fd688f",
+                "small": "https://images.unsplash.com/photo-1473081556163-2a17de81fc97?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=bdf1b214d49c834fbb25d19d07ea42df",
+                "thumb": "https://images.unsplash.com/photo-1473081556163-2a17de81fc97?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=f4d191a345310a79a23c983ca457075c"
+            },
+            "links": {
+                "self": "https://api.unsplash.com/photos/gKXKBY-C-Dk",
+                "html": "http://unsplash.com/photos/gKXKBY-C-Dk",
+                "download": "http://unsplash.com/photos/gKXKBY-C-Dk/download"
+            }
+        }
+    ]
+}

--- a/tests/Fixtures/Unsplash/search-photos.json
+++ b/tests/Fixtures/Unsplash/search-photos.json
@@ -1,0 +1,49 @@
+{
+    "total": 133,
+    "total_pages": 7,
+    "results": [
+        {
+            "id": "eOLpJytrbsQ",
+            "created_at": "2014-11-18T14:35:36-05:00",
+            "width": 4000,
+            "height": 3000,
+            "color": "#A7A2A1",
+            "blur_hash": "LaLXMa9Fx[D%~q%MtQM|kDRjtRIU",
+            "description": "A man drinking a coffee.",
+            "alt_description": "A man drinking a coffee.",
+            "user": {
+                "id": "Ul0QVz12Goo",
+                "username": "ugmonk",
+                "name": "Jeff Sheldon",
+                "first_name": "Jeff",
+                "last_name": "Sheldon",
+                "instagram_username": "instantgrammer",
+                "twitter_username": "ugmonk",
+                "portfolio_url": "http://ugmonk.com/",
+                "profile_image": {
+                    "small": "https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32&s=7cfe3b93750cb0c93e2f7caec08b5a41",
+                    "medium": "https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=64&w=64&s=5a9dc749c43ce5bd60870b129a40902f",
+                    "large": "https://images.unsplash.com/profile-1441298803695-accd94000cac?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=32085a077889586df88bfbe406692202"
+                },
+                "links": {
+                    "self": "https://api.unsplash.com/users/ugmonk",
+                    "html": "http://unsplash.com/@ugmonk",
+                    "photos": "https://api.unsplash.com/users/ugmonk/photos"
+                }
+            },
+            "current_user_collections": [],
+            "urls": {
+                "raw": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f",
+                "full": "https://hd.unsplash.com/photo-1416339306562-f3d12fefd36f",
+                "regular": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=92f3e02f63678acc8416d044e189f515",
+                "small": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=263af33585f9d32af39d165b000845eb",
+                "thumb": "https://images.unsplash.com/photo-1416339306562-f3d12fefd36f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=8aae34cf35df31a592f0bef16e6342ef"
+            },
+            "links": {
+                "self": "https://api.unsplash.com/photos/eOLpJytrbsQ",
+                "html": "http://unsplash.com/photos/eOLpJytrbsQ",
+                "download": "http://unsplash.com/photos/eOLpJytrbsQ/download"
+            }
+        }
+    ]
+}

--- a/tests/Integration/UnsplashClientTest.php
+++ b/tests/Integration/UnsplashClientTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Exceptions\UnsplashRequestFailed;
+use App\UnsplashClient;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('it searches photos', function () {
+    Config::set('services.unsplash.access_key', 'test');
+
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response(fixture('Unsplash/search-photos.json')),
+    ]);
+
+    $response = app(UnsplashClient::class)->searchPhotos('coffee', 2);
+
+    expect($response)->toBe(fixture('Unsplash/search-photos.json'));
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.unsplash.com/search/photos?query=coffee&page=2&per_page=12&orientation=landscape&content_filter=high'
+        && $request->hasHeader('Authorization', 'Client-ID test'));
+});
+
+test('it finds a photo', function () {
+    Config::set('services.unsplash.access_key', 'test');
+
+    Http::fake([
+        'api.unsplash.com/photos/eOLpJytrbsQ' => Http::response(fixture('Unsplash/photo.json')),
+    ]);
+
+    $photo = app(UnsplashClient::class)->findPhoto('eOLpJytrbsQ');
+
+    expect($photo)->toBe(fixture('Unsplash/photo.json'));
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.unsplash.com/photos/eOLpJytrbsQ'
+        && $request->hasHeader('Authorization', 'Client-ID test'));
+});
+
+test('it downloads a photo', function () {
+    Config::set('services.unsplash.access_key', 'test');
+
+    Http::fake([
+        'api.unsplash.com/photos/eOLpJytrbsQ/download' => Http::response([]),
+    ]);
+
+    app(UnsplashClient::class)->downloadPhoto('https://api.unsplash.com/photos/eOLpJytrbsQ/download');
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.unsplash.com/photos/eOLpJytrbsQ/download'
+        && $request->hasHeader('Authorization', 'Client-ID test'));
+});
+
+test('it throws an exception when photos cannot be searched', function () {
+    Http::fake([
+        'api.unsplash.com/search/photos*' => Http::response([], 500),
+    ]);
+
+    app(UnsplashClient::class)->searchPhotos('coffee');
+})->throws(UnsplashRequestFailed::class);
+
+test('it throws an exception when a photo cannot be found', function () {
+    Http::fake([
+        'api.unsplash.com/photos/eOLpJytrbsQ' => Http::response([], 404),
+    ]);
+
+    app(UnsplashClient::class)->findPhoto('eOLpJytrbsQ');
+})->throws(UnsplashRequestFailed::class);
+
+test('it throws an exception when the download endpoint fails', function () {
+    Http::fake([
+        'api.unsplash.com/photos/eOLpJytrbsQ/download' => Http::response([], 500),
+    ]);
+
+    app(UnsplashClient::class)->downloadPhoto('https://api.unsplash.com/photos/eOLpJytrbsQ/download');
+})->throws(UnsplashRequestFailed::class);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -44,3 +44,8 @@ use Illuminate\Support\Facades\Http;
 */
 
 /** @link https://pestphp.com/docs/helpers */
+
+function fixture(string $path): array
+{
+    return json_decode(file_get_contents(base_path("tests/Fixtures/{$path}")), true);
+}


### PR DESCRIPTION
This PR adds  #701 

----

Replace the manual Unsplash photo ID input in the article form with a Livewire-powered image picker.

The new picker searches Unsplash through a dedicated UnsplashClient, caches search responses, displays results in a scrollable grid with infinite loading, and lets authors preview and remove the selected image before saving. The form continues to submit only the selected Unsplash photo ID, preserving the existing article image synchronization flow.

Unsplash API access is centralized in UnsplashCLient, including photo search, photo lookup, download tracking, retry handling, timeouts, and custom failure exceptions. SyncArticleImage now uses this client to fetch the selected photo metadata an trigger the Unsplash download endpoint.

The implementation also adds Unsplash attribution in the search results and preview, introduces reusable test fixtures for Unsplash responses, and covers the picker and client behaviour with tests.

The README is also modified to explain the current flow. **Noticed** that the mentioned command no longer exists.

<img width="1766" height="1110" alt="image" src="https://github.com/user-attachments/assets/b0e0b63b-e9aa-4685-b853-13c23d4e9619" />
<img width="1766" height="1110" alt="image" src="https://github.com/user-attachments/assets/ebd21bb1-0acc-44a8-80fe-5b695f6be564" />
<img width="1766" height="1110" alt="image" src="https://github.com/user-attachments/assets/5fffb7a0-e1a1-4461-b9e1-0fcd0c96376d" />

